### PR TITLE
fix: improve error handling for missing .env.deploy configuration

### DIFF
--- a/devops-panel/auto-deploy.sh
+++ b/devops-panel/auto-deploy.sh
@@ -161,36 +161,70 @@ case $CHOICE in
         ;;
     3)
         echo -e "${YELLOW}→ Deploying to preview server...${NC}"
+        echo ""
 
         # Check if .env.deploy exists
         if [ ! -f "./.env.deploy" ]; then
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo -e "${RED}  Configuration Required${NC}"
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo ""
             echo -e "${YELLOW}⚠️  No deployment configuration found (.env.deploy)${NC}"
             echo ""
-            read -p "Do you want to run the configuration wizard? (Y/n): " -n 1 -r
+            echo -e "${BLUE}To deploy to your preview server, you need to configure:${NC}"
+            echo "  - Your domain (e.g., vln.gg)"
+            echo "  - Subdomain names (e.g., preview, dev, staging)"
+            echo "  - Server IP address"
+            echo "  - SSH keys for authentication"
             echo ""
 
-            if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-                if [ -f "./setup-deployment-config.sh" ]; then
-                    chmod +x ./setup-deployment-config.sh
-                    ./setup-deployment-config.sh
+            # Check if running interactively (has terminal)
+            if [ -t 0 ]; then
+                read -p "Do you want to run the configuration wizard now? (Y/n): " -n 1 -r < /dev/tty
+                echo ""
 
-                    # After setup, continue with deployment
-                    if [ -f "./.env.deploy" ]; then
+                if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+                    if [ -f "./setup-deployment-config.sh" ]; then
+                        chmod +x ./setup-deployment-config.sh
                         echo ""
-                        echo -e "${GREEN}✓ Configuration complete. Continuing with deployment...${NC}"
-                        echo ""
-                        sleep 2
+                        ./setup-deployment-config.sh
+
+                        # After setup, continue with deployment
+                        if [ -f "./.env.deploy" ]; then
+                            echo ""
+                            echo -e "${GREEN}✓ Configuration complete. Continuing with deployment...${NC}"
+                            echo ""
+                            sleep 2
+                        else
+                            echo -e "${RED}✗ Configuration was not completed. Exiting.${NC}"
+                            exit 1
+                        fi
                     else
-                        echo -e "${RED}✗ Configuration was not completed. Exiting.${NC}"
+                        echo -e "${RED}✗ setup-deployment-config.sh not found${NC}"
                         exit 1
                     fi
                 else
-                    echo -e "${RED}✗ setup-deployment-config.sh not found${NC}"
+                    echo ""
+                    echo -e "${YELLOW}Please configure .env.deploy first:${NC}"
+                    echo -e "${CYAN}  ./setup-deployment-config.sh${NC}"
+                    echo ""
                     exit 1
                 fi
             else
-                echo -e "${YELLOW}Please configure .env.deploy first:${NC}"
+                # Non-interactive mode (e.g., piped from curl)
+                echo -e "${YELLOW}Running in non-interactive mode (no terminal attached).${NC}"
+                echo ""
+                echo -e "${CYAN}To configure deployment, clone the repo and run:${NC}"
+                echo ""
+                echo -e "${CYAN}  git clone https://github.com/Fused-Gaming/DevOps.git${NC}"
+                echo -e "${CYAN}  cd DevOps/devops-panel${NC}"
                 echo -e "${CYAN}  ./setup-deployment-config.sh${NC}"
+                echo -e "${CYAN}  ./deploy-to-subdomain.sh SUB_DOMAIN1${NC}"
+                echo ""
+                echo -e "${YELLOW}Or use the interactive menu instead:${NC}"
+                echo -e "${CYAN}  curl -fsSL https://github.com/Fused-Gaming/DevOps/raw/main/devops-panel/auto-deploy.sh | bash${NC}"
+                echo -e "${CYAN}  # Then choose option 3 from the menu${NC}"
+                echo ""
                 exit 1
             fi
         fi
@@ -199,7 +233,7 @@ case $CHOICE in
             chmod +x ./deploy-to-subdomain.sh
             exec ./deploy-to-subdomain.sh
         else
-            echo -e "${RED}deploy-to-subdomain.sh not found${NC}"
+            echo -e "${RED}✗ deploy-to-subdomain.sh not found${NC}"
             exit 1
         fi
         ;;

--- a/devops-panel/deploy-to-subdomain.sh
+++ b/devops-panel/deploy-to-subdomain.sh
@@ -25,18 +25,68 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 if [ ! -f "$SCRIPT_DIR/.env.deploy" ]; then
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${RED}  Configuration Error${NC}"
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
     echo -e "${RED}✗ Configuration file not found: .env.deploy${NC}"
     echo ""
-    echo -e "${YELLOW}Run the configuration wizard first:${NC}"
+    echo -e "${YELLOW}The deployment configuration is missing. You need to run the setup wizard first.${NC}"
+    echo ""
+    echo -e "${BLUE}Option 1: Run the configuration wizard (Recommended)${NC}"
+    echo -e "${CYAN}  cd $SCRIPT_DIR${NC}"
     echo -e "${CYAN}  ./setup-deployment-config.sh${NC}"
+    echo ""
+    echo -e "${BLUE}Option 2: Copy and edit the example file manually${NC}"
+    echo -e "${CYAN}  cd $SCRIPT_DIR${NC}"
+    echo -e "${CYAN}  cp .env.deploy.example .env.deploy${NC}"
+    echo -e "${CYAN}  nano .env.deploy${NC}"
+    echo ""
+    echo -e "${BLUE}Required configuration:${NC}"
+    echo "  - TLD (e.g., vln.gg)"
+    echo "  - SUB_DOMAIN1 (e.g., preview)"
+    echo "  - SERVER_IP (your server IP address)"
+    echo "  - SSH_USER (default: root)"
+    echo "  - ROOT_SSH_KEY (your public SSH key)"
     echo ""
     exit 1
 fi
 
 # Load environment variables
+echo -e "${YELLOW}→ Loading configuration from .env.deploy...${NC}"
 set -a
 source "$SCRIPT_DIR/.env.deploy"
 set +a
+echo -e "${GREEN}✓ Configuration loaded${NC}"
+echo ""
+
+# Validate required variables
+REQUIRED_VARS=("TLD" "SERVER_IP" "SSH_USER" "DEPLOY_BASE_PATH")
+MISSING_VARS=()
+
+for var in "${REQUIRED_VARS[@]}"; do
+    if [ -z "${!var}" ]; then
+        MISSING_VARS+=("$var")
+    fi
+done
+
+if [ ${#MISSING_VARS[@]} -ne 0 ]; then
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${RED}  Configuration Error${NC}"
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo -e "${RED}✗ Missing required variables in .env.deploy:${NC}"
+    for var in "${MISSING_VARS[@]}"; do
+        echo -e "  ${YELLOW}- $var${NC}"
+    done
+    echo ""
+    echo -e "${YELLOW}Please run the configuration wizard to fix this:${NC}"
+    echo -e "${CYAN}  ./setup-deployment-config.sh${NC}"
+    echo ""
+    echo -e "${BLUE}Or manually edit .env.deploy and add the missing variables.${NC}"
+    echo ""
+    exit 1
+fi
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Parse Subdomain Argument


### PR DESCRIPTION
Enhanced error reporting and user guidance when configuration is missing:

**deploy-to-subdomain.sh:**
- Better error messages with visual formatting
- Clear instructions for fixing the issue
- Validates all required variables before proceeding
- Lists missing variables if configuration is incomplete
- Provides both wizard and manual setup options

**auto-deploy.sh:**
- Detects if running interactively vs piped from curl
- In interactive mode: Prompts to run wizard
- In non-interactive mode: Shows clear instructions
- Prevents confusing errors when stdin not available
- Improved formatting and readability

**Error scenarios handled:**
1. .env.deploy missing entirely
2. .env.deploy exists but missing required variables
3. Running via curl (non-interactive)
4. Running in terminal (interactive)

**User experience:**
- Clear error messages explaining what's wrong
- Step-by-step instructions to fix
- Detects environment (terminal vs curl)
- Prevents cryptic bash errors like 'invalid variable name'

This fixes the issue where AUTO_DEPLOY_MODE=preview would fail with unclear errors when .env.deploy was missing.