### PR TITLE
fix: prevent infinite loop in claude-usage-tracking workflow

### DIFF
--- a/.github/workflows/claude-usage-tracking.yml
+++ b/.github/workflows/claude-usage-tracking.yml
@@ -10,6 +10,9 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+# Prevent infinite loops - skip if commit is from bot
+# This works in conjunction with [skip ci] in commit message
+
 permissions:
   contents: write
   pull-requests: write
@@ -22,6 +25,10 @@ jobs:
   track-usage:
     name: 📊 Track Claude Code Usage
     runs-on: ubuntu-latest
+    # Skip if commit message contains [skip ci] or is from usage tracking bot
+    if: |
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(github.event.head_commit.message, 'chore: update Claude usage tracking')
     outputs:
       tokens_used: ${{ steps.calculate.outputs.tokens_used }}
       estimated_cost: ${{ steps.calculate.outputs.estimated_cost }}
@@ -118,18 +125,37 @@ jobs:
       - name: 💾 Commit Updated Usage File
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if [ -n "$(git status --porcelain CLAUDE_USAGE.md)" ]; then
             TOKENS="${{ steps.calculate.outputs.tokens_used }}"
             COST="${{ steps.calculate.outputs.estimated_cost }}"
-            ACTOR="${{ github.actor }}"
 
             git add CLAUDE_USAGE.md
-            git commit -m "chore: update Claude usage tracking" -m "Auto-updated by workflow" -m "Tokens: $TOKENS" -m "Cost: \$$COST" -m "Signed-off-by: $ACTOR <$ACTOR@users.noreply.github.com>"
-            git push
-            echo "✓ CLAUDE_USAGE.md updated and committed"
+            git commit -m "chore: update Claude usage tracking [skip ci]" -m "Auto-updated by workflow" -m "Tokens: $TOKENS" -m "Cost: \$$COST"
+
+            # Push with retry logic (up to 4 retries with exponential backoff)
+            MAX_RETRIES=4
+            RETRY_COUNT=0
+            DELAY=2
+
+            while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+              if git push origin main; then
+                echo "✓ CLAUDE_USAGE.md updated and committed"
+                break
+              else
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                  echo "⚠️  Push failed, retrying in ${DELAY}s... (Attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)"
+                  sleep $DELAY
+                  DELAY=$((DELAY * 2))
+                else
+                  echo "❌ Failed to push after $MAX_RETRIES attempts"
+                  exit 1
+                fi
+              fi
+            done
           else
             echo "ℹ️  No changes to CLAUDE_USAGE.md"
           fi


### PR DESCRIPTION
- Add skip condition for commits with [skip ci] or usage tracking commits
- Add [skip ci] flag to auto-commit message to prevent recursion
- Change bot identity to github-actions[bot]
- Add retry logic with exponential backoff for git push (2s, 4s, 8s, 16s)
- Fixes issue where workflow failed when trying to push back to main