### PR TITLE
Potential fix for code scanning alert no. 8: Server-side request forgery

### DIFF
--- a/devops-panel/app/api/github/route.ts
+++ b/devops-panel/app/api/github/route.ts
@@ -12,6 +12,14 @@ export async function GET(request: Request) {
     const githubToken = process.env.GITHUB_TOKEN;
     const { searchParams } = new URL(request.url);
     const repo = searchParams.get("repo") || "Fused-Gaming/DevOps";
+    // Validate repo: must match owner/repo, consisting of allowed chars only
+    const repoPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+    if (!repoPattern.test(repo)) {
+      return NextResponse.json(
+        { error: "Invalid repository format", workflows: [] },
+        { status: 400 }
+      );
+    }
 
     if (!githubToken) {
       return NextResponse.json({


### PR DESCRIPTION
Potential fix for [https://github.com/Fused-Gaming/DevOps/security/code-scanning/8](https://github.com/Fused-Gaming/DevOps/security/code-scanning/8)

To mitigate SSRF, sanitize and restrict the `repo` input before using it in the outgoing API request. The best way is to validate that the provided value strictly matches an allowed pattern—such as a GitHub "owner/repo" slug, forbidding any `/`, `\`, or `.` outside the single `/` separator and disallowing path traversal (`../`) or other malicious injections. Additionally, consider establishing a fixed allow-list of repositories if your use case permits. If dynamic choices are necessary, ensure the validated value cannot be abused for SSRF. Change only the handling of the `repo` parameter with a validation check; if the value fails, reject the request with an error.

- Edit within devops-panel/app/api/github/route.ts, code region where `repo` is assigned and used (lines 13–15).
- Implement a validation step after extracting `repo` to ensure it matches the pattern `/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/` (owner/repo slug).
- If validation fails, return an error response and do not proceed with the API request.
- No new dependencies for simple regex validation are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
