### PR TITLE
Potential fix for code scanning alert no. 2: Unused import

### DIFF
--- a/attorney-finder-bot/api/web/auth.py
+++ b/attorney-finder-bot/api/web/auth.py
@@ -6,7 +6,6 @@ import sys
 import json
 import hashlib
 import hmac
-from urllib.parse import parse_qs
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
 


### PR DESCRIPTION
Potential fix for [https://github.com/Fused-Gaming/DevOps/security/code-scanning/2](https://github.com/Fused-Gaming/DevOps/security/code-scanning/2)

To fix the problem, the unused import should be deleted. This means removing the line `from urllib.parse import parse_qs` entirely from the file. No other changes are necessary, as nothing in the code depends on this import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
