### PR TITLE
Potential fix for code scanning alert no. 4: Unused import

### DIFF
--- a/api/deployments.py
+++ b/api/deployments.py
@@ -3,7 +3,6 @@ Vercel deployments API endpoint
 """
 from http.server import BaseHTTPRequestHandler
 import json
-import os
 import subprocess
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Fused-Gaming/DevOps/security/code-scanning/4](https://github.com/Fused-Gaming/DevOps/security/code-scanning/4)

The recommended fix for an unused import is to remove the import statement for the unused module. In this case, this means deleting the line containing `import os` (line 6) in `api/deployments.py`. No other changes are necessary, and since neither `os` nor anything that would require its import is used in the rest of the code snippet, removing this line will not affect functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
